### PR TITLE
Fix footer content blocking issue

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -21,9 +21,9 @@ export default function RootLayout({
     <html lang="en">
       <body className={inter.className}>
         <main>{children}</main>
+        <BuyMeCoffeeButton />
         <Footer />
         <GoogleAnalytics gaId="G-3CBRHGJCW4" />
-        <BuyMeCoffeeButton />
       </body>
     </html>
   );

--- a/src/components/BuyMeCoffeeButton.tsx
+++ b/src/components/BuyMeCoffeeButton.tsx
@@ -3,7 +3,7 @@
 
 export default function BuyMeCoffeeButton() {
     return (
-        <div className="fixed right-[18px] bottom-[18px] z-[9999] transition-transform hover:-translate-y-1">
+        <div className="fixed right-[18px] bottom-[80px] z-[9999] transition-transform hover:-translate-y-1">
             <a
                 href="https://www.buymeacoffee.com/ollolabs"
                 target="_blank"

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -14,6 +14,9 @@ export default function Footer() {
                     </Link>
                 </div>
             </div>
+            <div className="container mt-4">
+                <p className="text-sm text-muted-foreground">For customer support, please reach us at contact@ollo.audio</p>
+            </div>
         </footer>
     );
 }


### PR DESCRIPTION
Move the "buy me a coffee" button to avoid blocking the footer content and add customer support text to the footer.

* Adjust the position of the "buy me a coffee" button in `src/components/BuyMeCoffeeButton.tsx` by changing the `bottom` CSS property to `80px`.
* Add the text "For customer support, please reach us at contact@ollo.audio" to the footer in `src/components/Footer.tsx`.
* Move the `BuyMeCoffeeButton` component above the `Footer` component in `src/app/layout.tsx`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/dtedesco1/ollo-web/pull/1?shareId=9c8164f4-ca67-41e5-9720-5b174bd07d03).